### PR TITLE
[STRUCTURE] Update create page

### DIFF
--- a/components/create/Contact.tsx
+++ b/components/create/Contact.tsx
@@ -8,28 +8,24 @@ import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LanguageIcon from '@mui/icons-material/Language';
 import { StyledTextField } from 'components/create/Styled';
+import LinksEditor from './common/LinksEditor';
 const Contact = () => {
-  const formRef = useRef() as RefObject<HTMLFormElement>;
-  const draftLink: ILink = {
-    label: '',
-    url: '',
-  };
   const { contact, setContact } = useContext(CreatePortfolioContext);
-  const onAddLink = () => {
-    contact.links?.push(draftLink);
-
-    setContact({ ...contact });
-    formRef.current?.reset();
-  };
   const onSubmit = () => {
     setContact({ ...contact });
   };
+  const setLinks = (links: ILink[]) => {
+    setContact({
+      ...contact,
+      links,
+    });
+  };
   const selectLinkIcon = (link: ILink) => {
-    switch (true) {
-      case link.url.includes('linkedin.com'):
+    switch (link.label.toLowerCase()) {
+      case 'linkedin':
         link.label = 'LinkedIn';
         return <LinkedInIcon />;
-      case link.url.includes('github.com'):
+      case 'github':
         link.label = 'GitHub';
         return <GitHubIcon />;
 
@@ -37,36 +33,25 @@ const Contact = () => {
         return <LanguageIcon />;
     }
   };
-
+  const openInNewTab = (url: string | URL | undefined) => {
+    const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
+    if (newWindow) newWindow.opener = null;
+  };
   return (
     <div>
       <Stack direction="column">
         <StyledTextField
-          label="Email Address"
+          label={'Email Address'}
           onChange={(element) => {
-            contact.email = element.target.value;
+            setContact({
+              ...contact,
+              email: element.target.value,
+            });
           }}
+          value={contact.email}
         />
-        <form ref={formRef}>
-          <Stack direction="column">
-            <StyledTextField
-              label="Label"
-              onChange={(element) => {
-                draftLink.label = element.target.value;
-              }}
-            />
-            <StyledTextField
-              label="URL"
-              onChange={(element) => {
-                draftLink.url = element.target.value;
-              }}
-            />
-          </Stack>
-        </form>
+        <LinksEditor links={contact.links || []} setLinks={setLinks} />
       </Stack>
-      <Button variant="outlined" onClick={onAddLink}>
-        Add Link
-      </Button>
       <div
         style={{
           display: 'flex',
@@ -92,7 +77,7 @@ const Contact = () => {
             {selectLinkIcon(link)}
             <span>
               <Typography>
-                <Link href={link.url} target="_blank" rel="noreferrer noopener">
+                <Link href="#" onClick={() => openInNewTab(link.url)}>
                   {link.label}
                 </Link>
               </Typography>

--- a/components/create/Contact.tsx
+++ b/components/create/Contact.tsx
@@ -1,8 +1,19 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { TextField, Input, Stack, Button } from '@mui/material';
+import {
+  TextField,
+  Input,
+  Stack,
+  Button,
+  Typography,
+  Grid,
+} from '@mui/material';
 import { useCallback, useState, useContext, useRef, RefObject } from 'react';
 import { IContact, ILink } from 'models/data/';
+import EmailIcon from '@mui/icons-material/Email';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LanguageIcon from '@mui/icons-material/Language';
 
 const Contact = () => {
   const formRef = useRef() as RefObject<HTMLFormElement>;
@@ -13,44 +24,92 @@ const Contact = () => {
   const { contact, setContact } = useContext(CreatePortfolioContext);
   const onAddLink = () => {
     contact.links?.push(link);
+    console.log(contact.links);
+    setContact({ ...contact });
     formRef.current?.reset();
   };
   const onSubmit = () => {
     // console.log(contact.links);
     setContact({ ...contact });
   };
+  const selectLinkIcon = (link: ILink) => {
+    switch (link.label.toLowerCase()) {
+      case 'linkedin':
+        link.label = 'LinkedIn';
+        return <LinkedInIcon />;
+      case 'github':
+        link.label = 'GitHub';
+        return <GitHubIcon />;
+
+      default:
+        return <LanguageIcon />;
+    }
+  };
+
   return (
-    <Stack direction="column" spacing={1}>
-      <TextField
-        label={'Email Address'}
-        variant="standard"
-        onChange={(element) => {
-          contact.email = element.target.value;
+    <div>
+      <Stack direction="column" spacing={1}>
+        <TextField
+          label={'Email Address'}
+          variant="standard"
+          onChange={(element) => {
+            contact.email = element.target.value;
+          }}
+        />
+        <form ref={formRef}>
+          <TextField
+            label={'Label'}
+            variant="standard"
+            onChange={(element) => {
+              link.label = element.target.value;
+            }}
+          />
+          <TextField
+            label={'URL'}
+            variant="standard"
+            onChange={(element) => {
+              link.url = element.target.value;
+            }}
+          />
+        </form>
+      </Stack>
+      {/* <Grid container sx={{ color: 'text.primary' }}> */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
         }}
-      />
-      <form ref={formRef}>
-        <TextField
-          label={'Label'}
-          variant="standard"
-          onChange={(element) => {
-            link.label = element.target.value;
-          }}
-        />
-        <TextField
-          label={'URL'}
-          variant="standard"
-          onChange={(element) => {
-            link.url = element.target.value;
-          }}
-        />
-      </form>
+      >
+        <EmailIcon />
+        <span>
+          <Typography>{contact.email}</Typography>
+        </span>
+      </div>
+      <Typography>Your links</Typography>
+      {contact.links?.map((link, index: number) => (
+        <Stack key={index}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            {selectLinkIcon(link)}
+            <span>
+              <Typography>{link.label}</Typography>
+            </span>
+          </div>
+        </Stack>
+      ))}
       <Button variant="outlined" onClick={onAddLink}>
         Add Link
       </Button>
       <Button variant="outlined" onClick={onSubmit}>
         Review your information
       </Button>
-    </Stack>
+    </div>
   );
 };
 

--- a/components/create/Contact.tsx
+++ b/components/create/Contact.tsx
@@ -1,20 +1,13 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import {
-  TextField,
-  Input,
-  Stack,
-  Button,
-  Typography,
-  Grid,
-} from '@mui/material';
-import { useCallback, useState, useContext, useRef, RefObject } from 'react';
-import { IContact, ILink } from 'models/data/';
+import { Stack, Button, Typography, Link } from '@mui/material';
+import { useContext, useRef, RefObject } from 'react';
+import { ILink } from 'models/data/';
 import EmailIcon from '@mui/icons-material/Email';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LanguageIcon from '@mui/icons-material/Language';
-
+import { StyledTextField } from 'components/create/Styled';
 const Contact = () => {
   const formRef = useRef() as RefObject<HTMLFormElement>;
   const link: ILink = {
@@ -24,12 +17,11 @@ const Contact = () => {
   const { contact, setContact } = useContext(CreatePortfolioContext);
   const onAddLink = () => {
     contact.links?.push(link);
-    console.log(contact.links);
+
     setContact({ ...contact });
     formRef.current?.reset();
   };
   const onSubmit = () => {
-    // console.log(contact.links);
     setContact({ ...contact });
   };
   const selectLinkIcon = (link: ILink) => {
@@ -45,35 +37,39 @@ const Contact = () => {
         return <LanguageIcon />;
     }
   };
-
+  const openInNewTab = (url: string | URL | undefined) => {
+    const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
+    if (newWindow) newWindow.opener = null;
+  };
   return (
     <div>
-      <Stack direction="column" spacing={1}>
-        <TextField
+      <Stack direction="column">
+        <StyledTextField
           label={'Email Address'}
-          variant="standard"
           onChange={(element) => {
             contact.email = element.target.value;
           }}
         />
         <form ref={formRef}>
-          <TextField
-            label={'Label'}
-            variant="standard"
-            onChange={(element) => {
-              link.label = element.target.value;
-            }}
-          />
-          <TextField
-            label={'URL'}
-            variant="standard"
-            onChange={(element) => {
-              link.url = element.target.value;
-            }}
-          />
+          <Stack direction="column">
+            <StyledTextField
+              label={'Label'}
+              onChange={(element) => {
+                link.label = element.target.value;
+              }}
+            />
+            <StyledTextField
+              label={'URL'}
+              onChange={(element) => {
+                link.url = element.target.value;
+              }}
+            />
+          </Stack>
         </form>
       </Stack>
-      {/* <Grid container sx={{ color: 'text.primary' }}> */}
+      <Button variant="outlined" onClick={onAddLink}>
+        Add Link
+      </Button>
       <div
         style={{
           display: 'flex',
@@ -98,16 +94,17 @@ const Contact = () => {
           >
             {selectLinkIcon(link)}
             <span>
-              <Typography>{link.label}</Typography>
+              <Typography>
+                <Link href="#" onClick={() => openInNewTab(link.url)}>
+                  {link.label}
+                </Link>
+              </Typography>
             </span>
           </div>
         </Stack>
       ))}
-      <Button variant="outlined" onClick={onAddLink}>
-        Add Link
-      </Button>
       <Button variant="outlined" onClick={onSubmit}>
-        Review your information
+        Review Your Information
       </Button>
     </div>
   );

--- a/components/create/Contact.tsx
+++ b/components/create/Contact.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 import { Stack, Button, Typography, Link } from '@mui/material';
-import { useContext, useRef, RefObject } from 'react';
+import { useContext, useState } from 'react';
 import { ILink } from 'models/data/';
 import EmailIcon from '@mui/icons-material/Email';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
@@ -11,6 +11,7 @@ import { StyledTextField } from 'components/create/Styled';
 import LinksEditor from './common/LinksEditor';
 const Contact = () => {
   const { contact, setContact } = useContext(CreatePortfolioContext);
+  const [email, setEmail] = useState('');
   const onSubmit = () => {
     setContact({ ...contact });
   };
@@ -21,11 +22,11 @@ const Contact = () => {
     });
   };
   const selectLinkIcon = (link: ILink) => {
-    switch (link.label.toLowerCase()) {
-      case 'linkedin':
+    switch (true) {
+      case link.url.includes('linkedin.com'):
         link.label = 'LinkedIn';
         return <LinkedInIcon />;
-      case 'github':
+      case link.url.includes('github.com'):
         link.label = 'GitHub';
         return <GitHubIcon />;
 
@@ -33,22 +34,23 @@ const Contact = () => {
         return <LanguageIcon />;
     }
   };
-  const openInNewTab = (url: string | URL | undefined) => {
-    const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
-    if (newWindow) newWindow.opener = null;
-  };
   return (
     <div>
       <Stack direction="column">
         <StyledTextField
-          label={'Email Address'}
-          onChange={(element) => {
-            setContact({
-              ...contact,
-              email: element.target.value,
-            });
+          label="Email Address"
+          value={email}
+          onChange={(event) => {
+            setEmail(event.target.value);
           }}
-          value={contact.email}
+          onKeyPress={(element: any) => {
+            if (element.key === 'Enter') {
+              setContact({
+                ...contact,
+                email: element.target.value,
+              });
+            }
+          }}
         />
         <LinksEditor links={contact.links || []} setLinks={setLinks} />
       </Stack>
@@ -77,7 +79,7 @@ const Contact = () => {
             {selectLinkIcon(link)}
             <span>
               <Typography>
-                <Link href="#" onClick={() => openInNewTab(link.url)}>
+                <Link href={link.url} target="_blank" rel="noreferrer noopener">
                   {link.label}
                 </Link>
               </Typography>

--- a/components/create/Contact.tsx
+++ b/components/create/Contact.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
+import { TextField, Input, Stack, Button } from '@mui/material';
+import { useCallback, useState, useContext, useRef, RefObject } from 'react';
+import { IContact, ILink } from 'models/data/';
+
+const Contact = () => {
+  const formRef = useRef() as RefObject<HTMLFormElement>;
+  const link: ILink = {
+    label: '',
+    url: '',
+  };
+  const { contact, setContact } = useContext(CreatePortfolioContext);
+  const onAddLink = () => {
+    contact.links?.push(link);
+    formRef.current?.reset();
+  };
+  const onSubmit = () => {
+    // console.log(contact.links);
+    setContact({ ...contact });
+  };
+  return (
+    <Stack direction="column" spacing={1}>
+      <TextField
+        label={'Email Address'}
+        variant="standard"
+        onChange={(element) => {
+          contact.email = element.target.value;
+        }}
+      />
+      <form ref={formRef}>
+        <TextField
+          label={'Label'}
+          variant="standard"
+          onChange={(element) => {
+            link.label = element.target.value;
+          }}
+        />
+        <TextField
+          label={'URL'}
+          variant="standard"
+          onChange={(element) => {
+            link.url = element.target.value;
+          }}
+        />
+      </form>
+      <Button variant="outlined" onClick={onAddLink}>
+        Add Link
+      </Button>
+      <Button variant="outlined" onClick={onSubmit}>
+        Review your information
+      </Button>
+    </Stack>
+  );
+};
+
+export default Contact;

--- a/components/create/Contact.tsx
+++ b/components/create/Contact.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { Stack, Button, Typography, Link } from '@mui/material';
-import { useContext, useState } from 'react';
+import { Stack, Typography, Link } from '@mui/material';
+import { useContext } from 'react';
 import { ILink } from 'models/data/';
 import EmailIcon from '@mui/icons-material/Email';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
@@ -11,10 +11,6 @@ import { StyledTextField } from 'components/create/Styled';
 import LinksEditor from './common/LinksEditor';
 const Contact = () => {
   const { contact, setContact } = useContext(CreatePortfolioContext);
-  const [email, setEmail] = useState('');
-  const onSubmit = () => {
-    setContact({ ...contact });
-  };
   const setLinks = (links: ILink[]) => {
     setContact({
       ...contact,
@@ -39,18 +35,13 @@ const Contact = () => {
       <Stack direction="column">
         <StyledTextField
           label="Email Address"
-          value={email}
-          onChange={(event) => {
-            setEmail(event.target.value);
+          onChange={(element) => {
+            setContact({
+              ...contact,
+              email: element.target.value,
+            });
           }}
-          onKeyPress={(element: any) => {
-            if (element.key === 'Enter') {
-              setContact({
-                ...contact,
-                email: element.target.value,
-              });
-            }
-          }}
+          value={contact.email}
         />
         <LinksEditor links={contact.links || []} setLinks={setLinks} />
       </Stack>
@@ -87,9 +78,6 @@ const Contact = () => {
           </div>
         </Stack>
       ))}
-      <Button variant="outlined" onClick={onSubmit}>
-        Review Your Information
-      </Button>
     </div>
   );
 };

--- a/components/create/Contact.tsx
+++ b/components/create/Contact.tsx
@@ -42,7 +42,7 @@ const Contact = () => {
     <div>
       <Stack direction="column">
         <StyledTextField
-          label={'Email Address'}
+          label="Email Address"
           onChange={(element) => {
             contact.email = element.target.value;
           }}
@@ -50,13 +50,13 @@ const Contact = () => {
         <form ref={formRef}>
           <Stack direction="column">
             <StyledTextField
-              label={'Label'}
+              label="Label"
               onChange={(element) => {
                 draftLink.label = element.target.value;
               }}
             />
             <StyledTextField
-              label={'URL'}
+              label="URL"
               onChange={(element) => {
                 draftLink.url = element.target.value;
               }}

--- a/components/create/Contact.tsx
+++ b/components/create/Contact.tsx
@@ -10,13 +10,13 @@ import LanguageIcon from '@mui/icons-material/Language';
 import { StyledTextField } from 'components/create/Styled';
 const Contact = () => {
   const formRef = useRef() as RefObject<HTMLFormElement>;
-  const link: ILink = {
+  const draftLink: ILink = {
     label: '',
     url: '',
   };
   const { contact, setContact } = useContext(CreatePortfolioContext);
   const onAddLink = () => {
-    contact.links?.push(link);
+    contact.links?.push(draftLink);
 
     setContact({ ...contact });
     formRef.current?.reset();
@@ -25,11 +25,11 @@ const Contact = () => {
     setContact({ ...contact });
   };
   const selectLinkIcon = (link: ILink) => {
-    switch (link.label.toLowerCase()) {
-      case 'linkedin':
+    switch (true) {
+      case link.url.includes('linkedin.com'):
         link.label = 'LinkedIn';
         return <LinkedInIcon />;
-      case 'github':
+      case link.url.includes('github.com'):
         link.label = 'GitHub';
         return <GitHubIcon />;
 
@@ -37,10 +37,7 @@ const Contact = () => {
         return <LanguageIcon />;
     }
   };
-  const openInNewTab = (url: string | URL | undefined) => {
-    const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
-    if (newWindow) newWindow.opener = null;
-  };
+
   return (
     <div>
       <Stack direction="column">
@@ -55,13 +52,13 @@ const Contact = () => {
             <StyledTextField
               label={'Label'}
               onChange={(element) => {
-                link.label = element.target.value;
+                draftLink.label = element.target.value;
               }}
             />
             <StyledTextField
               label={'URL'}
               onChange={(element) => {
-                link.url = element.target.value;
+                draftLink.url = element.target.value;
               }}
             />
           </Stack>
@@ -95,7 +92,7 @@ const Contact = () => {
             {selectLinkIcon(link)}
             <span>
               <Typography>
-                <Link href="#" onClick={() => openInNewTab(link.url)}>
+                <Link href={link.url} target="_blank" rel="noreferrer noopener">
                   {link.label}
                 </Link>
               </Typography>

--- a/components/create/CreatePorfolioContext.tsx
+++ b/components/create/CreatePorfolioContext.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext } from 'react';
+// import { Dispatch, SetStateAction, useContext } from 'react';
 import * as React from 'react';
 import { IWorkHistory, ISkills, IProject, IContact } from 'models/data/';
 

--- a/components/create/CreatePorfolioContext.tsx
+++ b/components/create/CreatePorfolioContext.tsx
@@ -1,7 +1,6 @@
 import { Dispatch, SetStateAction, useContext } from 'react';
 import * as React from 'react';
 import { IWorkHistory, ISkills, IProject, IContact } from 'models/data/';
-import { KinesisVideoArchivedMedia } from 'aws-sdk';
 
 const CreatePortfolioContext = React.createContext({
   title: '',

--- a/components/create/CreatePorfolioContext.tsx
+++ b/components/create/CreatePorfolioContext.tsx
@@ -1,8 +1,7 @@
-// import { Dispatch, SetStateAction, useContext } from 'react';
-import * as React from 'react';
 import { IWorkHistory, ISkills, IProject, IContact } from 'models/data/';
+import { createContext } from 'react';
 
-const CreatePortfolioContext = React.createContext({
+const CreatePortfolioContext = createContext({
   title: '',
   setTitle: (title: string) => {},
   name: '',

--- a/components/create/CreatePorfolioContext.tsx
+++ b/components/create/CreatePorfolioContext.tsx
@@ -1,0 +1,24 @@
+import { Dispatch, SetStateAction, useContext } from 'react';
+import * as React from 'react';
+import { IWorkHistory, ISkills, IProject, IContact } from 'models/data/';
+import { KinesisVideoArchivedMedia } from 'aws-sdk';
+
+const CreatePortfolioContext = React.createContext({
+  title: '',
+  setTitle: (title: string) => {},
+  name: '',
+  setName: (name: string) => {},
+  headshot: '',
+  setHeadShot: (headshot: string) => {},
+  about: '',
+  setAbout: (about: string) => {},
+  work: [] as IWorkHistory[],
+  setWork: (work: IWorkHistory[]) => {},
+  skills: {} as ISkills,
+  setSkills: (skills: ISkills) => {},
+  projects: [] as IProject[],
+  setProjects: (projects: IProject[]) => {},
+  contact: {} as IContact,
+  setContact: (contact: IContact) => {},
+});
+export default CreatePortfolioContext;

--- a/components/create/Introduction.tsx
+++ b/components/create/Introduction.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback, useContext } from 'react';
+import { TextField } from '@mui/material';
+
+import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
+const Introduction = () => {
+  const {
+    title,
+    setTitle,
+    name,
+    setName,
+    headshot,
+    setHeadShot,
+    about,
+    setAbout,
+  } = useContext(CreatePortfolioContext);
+  return (
+    <div>
+      <TextField
+        label={'title'}
+        onChange={(event) => {
+          setTitle(event.target.value);
+        }}
+        variant="standard"
+      />
+      <TextField
+        label={'name'}
+        onChange={(event) => {
+          setName(event.target.value);
+        }}
+        variant="standard"
+      />
+      <TextField
+        label={'headshot'}
+        onChange={(event) => {
+          setHeadShot(event.target.value);
+        }}
+        variant="standard"
+      />
+      <TextField
+        label={'about'}
+        onChange={(event) => {
+          setAbout(event.target.value);
+        }}
+        variant="standard"
+      />
+    </div>
+  );
+};
+export default Introduction;

--- a/components/create/Introduction.tsx
+++ b/components/create/Introduction.tsx
@@ -21,26 +21,26 @@ const Introduction = () => {
     <div>
       <Stack direction="column" spacing={1}>
         <StyledTextField
-          label={'Title your portfolio'}
+          label="Title your portfolio"
           onChange={(event) => {
             setTitle(event.target.value);
           }}
         />
         <StyledTextField
-          label={'Full Name'}
+          label="Full Name"
           onChange={(event) => {
             setName(event.target.value);
           }}
         />
 
         <StyledTextField
-          label={'Upload Picture'}
+          label="Upload Picture"
           onChange={(event) => {
             setHeadShot(event.target.value);
           }}
         />
         <StyledParagraphTextField
-          label={'About Yourself'}
+          label="About Yourself"
           multiline
           rows={4}
           onChange={(event) => {

--- a/components/create/Introduction.tsx
+++ b/components/create/Introduction.tsx
@@ -29,6 +29,7 @@ const Introduction = () => {
         }}
         variant="standard"
       />
+
       <TextField
         label={'headshot'}
         onChange={(event) => {

--- a/components/create/Introduction.tsx
+++ b/components/create/Introduction.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useContext } from 'react';
-import { TextField } from '@mui/material';
+import { Stack, TextField } from '@mui/material';
+import {
+  StyledTextField,
+  StyledParagraphTextField,
+} from 'components/create/Styled';
 
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 const Introduction = () => {
@@ -15,35 +19,35 @@ const Introduction = () => {
   } = useContext(CreatePortfolioContext);
   return (
     <div>
-      <TextField
-        label={'title'}
-        onChange={(event) => {
-          setTitle(event.target.value);
-        }}
-        variant="standard"
-      />
-      <TextField
-        label={'name'}
-        onChange={(event) => {
-          setName(event.target.value);
-        }}
-        variant="standard"
-      />
+      <Stack direction="column" spacing={1}>
+        <StyledTextField
+          label={'Title your portfolio'}
+          onChange={(event) => {
+            setTitle(event.target.value);
+          }}
+        />
+        <StyledTextField
+          label={'Full Name'}
+          onChange={(event) => {
+            setName(event.target.value);
+          }}
+        />
 
-      <TextField
-        label={'headshot'}
-        onChange={(event) => {
-          setHeadShot(event.target.value);
-        }}
-        variant="standard"
-      />
-      <TextField
-        label={'about'}
-        onChange={(event) => {
-          setAbout(event.target.value);
-        }}
-        variant="standard"
-      />
+        <StyledTextField
+          label={'Upload Picture'}
+          onChange={(event) => {
+            setHeadShot(event.target.value);
+          }}
+        />
+        <StyledParagraphTextField
+          label={'About Yourself'}
+          multiline
+          rows={4}
+          onChange={(event) => {
+            setAbout(event.target.value);
+          }}
+        />
+      </Stack>
     </div>
   );
 };

--- a/components/create/Introduction.tsx
+++ b/components/create/Introduction.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useContext } from 'react';
-import { Stack, TextField } from '@mui/material';
+import React, { useContext } from 'react';
+import { Stack } from '@mui/material';
 import {
   StyledTextField,
   StyledParagraphTextField,

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { TextField, Input, Stack, Button, Typography } from '@mui/material';
-import { useCallback, useState, useContext, useRef, RefObject } from 'react';
+import { TextField, Stack, Button } from '@mui/material';
+import { useContext, useRef, RefObject } from 'react';
 import { IProject, ILink } from 'models/data/';
-import GitHubIcon from '@mui/icons-material/GitHub';
-import LanguageIcon from '@mui/icons-material/Language';
-import CodeIcon from '@mui/icons-material/Code';
-import { linkSync } from 'fs';
+import { StyledTextField, StyledButton } from 'components/create/Styled';
 
 const Project = () => {
   const formRef = useRef() as RefObject<HTMLFormElement>;
@@ -25,10 +22,6 @@ const Project = () => {
     url: '',
   };
   const { projects, setProjects } = useContext(CreatePortfolioContext);
-  // const [position, setPosition] = useState('');
-  // const [company, setCompany] = useState('');
-  // const [dateWorked, setDateWorked] = useState('');
-  // const [description, setDescription] = useState('');
   const onSubmit = async () => {
     entry.links?.push(source);
     entry.links?.push(demo);
@@ -36,60 +29,46 @@ const Project = () => {
     setProjects([...projects]);
     formRef.current?.reset();
   };
-  // const selectLinkIcon = (link: ILink) => {
-  //   switch (link.label.toLowerCase()) {
-  //     case 'source':
-  //       link.label = 'source';
-  //       return <CodeIcon />;
-
-  //     default:
-  //       return <LanguageIcon />;
-  //   }
-  // };
   return (
     <form ref={formRef}>
       <Stack direction="column" spacing={1}>
-        <TextField
+        <StyledTextField
           label={'Title'}
-          variant="standard"
           onChange={(element) => {
             entry.title = element.target.value;
           }}
         />
-        <TextField
+        <StyledTextField
           label={'Picture'}
-          variant="standard"
           onChange={(element) => {
             entry.picture = element.target.value;
           }}
         />
-        <TextField
+        <StyledTextField
           label={'Summary'}
-          variant="standard"
+          multiline
+          rows={4}
           onChange={(element) => {
             entry.summary = element.target.value;
           }}
         />
-
-        <TextField
+        <StyledTextField
           label={'Link to Source Code'}
-          variant="standard"
           onChange={(element) => {
             source.label = 'source';
             source.url = element.target.value;
           }}
         />
-        <TextField
+        <StyledTextField
           label={'Link to Live Demo'}
-          variant="standard"
           onChange={(element) => {
             demo.label = 'demo';
             demo.url = element.target.value;
           }}
         />
-        <Button variant="outlined" onClick={onSubmit}>
+        <StyledButton variant="outlined" onClick={onSubmit}>
           Add Project
-        </Button>
+        </StyledButton>
       </Stack>
     </form>
   );

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -7,8 +7,6 @@ import { StyledTextField, StyledButton } from 'components/create/Styled';
 import LinksEditor from './common/LinksEditor';
 
 const Project = () => {
-  // useState gives you more control over the data being input/displayed
-  // and is more idiomatic for React compared to how this was previously implemented
   const [draftEntry, setDraftEntry] = React.useState<IProject>({
     title: '',
     picture: '',

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -7,25 +7,25 @@ import { StyledTextField, StyledButton } from 'components/create/Styled';
 
 const Project = () => {
   const formRef = useRef() as RefObject<HTMLFormElement>;
-  const entry: IProject = {
+  const draftEntry: IProject = {
     title: '',
     picture: '',
     summary: '',
     links: [],
   };
-  const source: ILink = {
+  const draftSource: ILink = {
     label: '',
     url: '',
   };
-  const demo: ILink = {
+  const draftDemo: ILink = {
     label: '',
     url: '',
   };
   const { projects, setProjects } = useContext(CreatePortfolioContext);
   const onSubmit = async () => {
-    entry.links?.push(source);
-    entry.links?.push(demo);
-    projects.push(entry);
+    draftEntry.links?.push(draftSource);
+    draftEntry.links?.push(draftDemo);
+    projects.push(draftEntry);
     setProjects([...projects]);
     formRef.current?.reset();
   };
@@ -35,13 +35,13 @@ const Project = () => {
         <StyledTextField
           label={'Title'}
           onChange={(element) => {
-            entry.title = element.target.value;
+            draftEntry.title = element.target.value;
           }}
         />
         <StyledTextField
           label={'Picture'}
           onChange={(element) => {
-            entry.picture = element.target.value;
+            draftEntry.picture = element.target.value;
           }}
         />
         <StyledTextField
@@ -49,21 +49,21 @@ const Project = () => {
           multiline
           rows={4}
           onChange={(element) => {
-            entry.summary = element.target.value;
+            draftEntry.summary = element.target.value;
           }}
         />
         <StyledTextField
           label={'Link to Source Code'}
           onChange={(element) => {
-            source.label = 'source';
-            source.url = element.target.value;
+            draftSource.label = 'source';
+            draftSource.url = element.target.value;
           }}
         />
         <StyledTextField
           label={'Link to Live Demo'}
           onChange={(element) => {
-            demo.label = 'demo';
-            demo.url = element.target.value;
+            draftDemo.label = 'demo';
+            draftDemo.url = element.target.value;
           }}
         />
         <StyledButton variant="outlined" onClick={onSubmit}>

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -22,7 +22,7 @@ const Project = () => {
     url: '',
   };
   const { projects, setProjects } = useContext(CreatePortfolioContext);
-  const onSubmit = async () => {
+  const onSubmit = () => {
     draftEntry.links?.push(draftSource);
     draftEntry.links?.push(draftDemo);
     projects.push(draftEntry);
@@ -33,19 +33,19 @@ const Project = () => {
     <form ref={formRef}>
       <Stack direction="column" spacing={1}>
         <StyledTextField
-          label={'Title'}
+          label="Title"
           onChange={(element) => {
             draftEntry.title = element.target.value;
           }}
         />
         <StyledTextField
-          label={'Picture'}
+          label="Picture"
           onChange={(element) => {
             draftEntry.picture = element.target.value;
           }}
         />
         <StyledTextField
-          label={'Summary'}
+          label="Summary"
           multiline
           rows={4}
           onChange={(element) => {
@@ -53,14 +53,14 @@ const Project = () => {
           }}
         />
         <StyledTextField
-          label={'Link to Source Code'}
+          label="Link to Source Code"
           onChange={(element) => {
             draftSource.label = 'source';
             draftSource.url = element.target.value;
           }}
         />
         <StyledTextField
-          label={'Link to Live Demo'}
+          label="Link to Live Demo"
           onChange={(element) => {
             draftDemo.label = 'demo';
             draftDemo.url = element.target.value;

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -1,74 +1,81 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { Stack } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import { useContext, useRef, RefObject } from 'react';
 import { IProject, ILink } from 'models/data/';
 import { StyledTextField, StyledButton } from 'components/create/Styled';
+import LinksEditor from './common/LinksEditor';
 
 const Project = () => {
-  const formRef = useRef() as RefObject<HTMLFormElement>;
-  const draftEntry: IProject = {
+  // useState gives you more control over the data being input/displayed
+  // and is more idiomatic for React compared to how this was previously implemented
+  const [draftEntry, setDraftEntry] = React.useState<IProject>({
     title: '',
     picture: '',
     summary: '',
     links: [],
-  };
-  const draftSource: ILink = {
-    label: '',
-    url: '',
-  };
-  const draftDemo: ILink = {
-    label: '',
-    url: '',
-  };
+  });
   const { projects, setProjects } = useContext(CreatePortfolioContext);
+  const setLinks = (links: ILink[]) => {
+    setDraftEntry({
+      ...draftEntry,
+      links,
+    });
+  };
   const onSubmit = () => {
-    draftEntry.links?.push(draftSource);
-    draftEntry.links?.push(draftDemo);
-    projects.push(draftEntry);
-    setProjects([...projects]);
-    formRef.current?.reset();
+    setProjects([...projects, draftEntry]);
+    setDraftEntry({
+      title: '',
+      picture: '',
+      summary: '',
+      links: [],
+    });
   };
   return (
-    <form ref={formRef}>
+    <form>
       <Stack direction="column" spacing={1}>
         <StyledTextField
-          label="Title"
+          label={'Title'}
           onChange={(element) => {
-            draftEntry.title = element.target.value;
+            setDraftEntry({
+              ...draftEntry,
+              title: element.target.value,
+            });
           }}
+          value={draftEntry.title}
         />
         <StyledTextField
-          label="Picture"
+          label={'Picture'}
           onChange={(element) => {
-            draftEntry.picture = element.target.value;
+            setDraftEntry({
+              ...draftEntry,
+              picture: element.target.value,
+            });
           }}
+          value={draftEntry.picture}
         />
         <StyledTextField
-          label="Summary"
+          label={'Summary'}
           multiline
           rows={4}
           onChange={(element) => {
-            draftEntry.summary = element.target.value;
+            setDraftEntry({
+              ...draftEntry,
+              summary: element.target.value,
+            });
           }}
+          value={draftEntry.summary}
         />
-        <StyledTextField
-          label="Link to Source Code"
-          onChange={(element) => {
-            draftSource.label = 'source';
-            draftSource.url = element.target.value;
-          }}
-        />
-        <StyledTextField
-          label="Link to Live Demo"
-          onChange={(element) => {
-            draftDemo.label = 'demo';
-            draftDemo.url = element.target.value;
-          }}
-        />
+        <LinksEditor links={draftEntry.links || []} setLinks={setLinks} />
         <StyledButton variant="outlined" onClick={onSubmit}>
           Add Project
         </StyledButton>
+        <Typography>Your projects</Typography>
+        <ul>
+          {projects.map((project, index) => (
+            <li key={index}>{project.title}</li>
+          ))}
+        </ul>
       </Stack>
     </form>
   );

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { TextField, Stack, Button } from '@mui/material';
+import { Stack } from '@mui/material';
 import { useContext, useRef, RefObject } from 'react';
 import { IProject, ILink } from 'models/data/';
 import { StyledTextField, StyledButton } from 'components/create/Styled';

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 import { Stack, Typography } from '@mui/material';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { IProject, ILink } from 'models/data/';
 import { StyledTextField, StyledButton } from 'components/create/Styled';
 import LinksEditor from './common/LinksEditor';
 
 const Project = () => {
-  const [draftEntry, setDraftEntry] = React.useState<IProject>({
+  const [draftEntry, setDraftEntry] = useState<IProject>({
     title: '',
     picture: '',
     summary: '',

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 import { Stack, Typography } from '@mui/material';
-import { useContext, useRef, RefObject } from 'react';
+import { useContext } from 'react';
 import { IProject, ILink } from 'models/data/';
 import { StyledTextField, StyledButton } from 'components/create/Styled';
 import LinksEditor from './common/LinksEditor';
@@ -35,7 +35,7 @@ const Project = () => {
     <form>
       <Stack direction="column" spacing={1}>
         <StyledTextField
-          label={'Title'}
+          label="Title"
           onChange={(element) => {
             setDraftEntry({
               ...draftEntry,
@@ -45,7 +45,7 @@ const Project = () => {
           value={draftEntry.title}
         />
         <StyledTextField
-          label={'Picture'}
+          label="Picture"
           onChange={(element) => {
             setDraftEntry({
               ...draftEntry,
@@ -55,7 +55,7 @@ const Project = () => {
           value={draftEntry.picture}
         />
         <StyledTextField
-          label={'Summary'}
+          label="Summary"
           multiline
           rows={4}
           onChange={(element) => {

--- a/components/create/Project.tsx
+++ b/components/create/Project.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
+import { TextField, Input, Stack, Button, Typography } from '@mui/material';
+import { useCallback, useState, useContext, useRef, RefObject } from 'react';
+import { IProject, ILink } from 'models/data/';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LanguageIcon from '@mui/icons-material/Language';
+import CodeIcon from '@mui/icons-material/Code';
+import { linkSync } from 'fs';
+
+const Project = () => {
+  const formRef = useRef() as RefObject<HTMLFormElement>;
+  const entry: IProject = {
+    title: '',
+    picture: '',
+    summary: '',
+    links: [],
+  };
+  const source: ILink = {
+    label: '',
+    url: '',
+  };
+  const demo: ILink = {
+    label: '',
+    url: '',
+  };
+  const { projects, setProjects } = useContext(CreatePortfolioContext);
+  // const [position, setPosition] = useState('');
+  // const [company, setCompany] = useState('');
+  // const [dateWorked, setDateWorked] = useState('');
+  // const [description, setDescription] = useState('');
+  const onSubmit = async () => {
+    entry.links?.push(source);
+    entry.links?.push(demo);
+    projects.push(entry);
+    setProjects([...projects]);
+    formRef.current?.reset();
+  };
+  // const selectLinkIcon = (link: ILink) => {
+  //   switch (link.label.toLowerCase()) {
+  //     case 'source':
+  //       link.label = 'source';
+  //       return <CodeIcon />;
+
+  //     default:
+  //       return <LanguageIcon />;
+  //   }
+  // };
+  return (
+    <form ref={formRef}>
+      <Stack direction="column" spacing={1}>
+        <TextField
+          label={'Title'}
+          variant="standard"
+          onChange={(element) => {
+            entry.title = element.target.value;
+          }}
+        />
+        <TextField
+          label={'Picture'}
+          variant="standard"
+          onChange={(element) => {
+            entry.picture = element.target.value;
+          }}
+        />
+        <TextField
+          label={'Summary'}
+          variant="standard"
+          onChange={(element) => {
+            entry.summary = element.target.value;
+          }}
+        />
+
+        <TextField
+          label={'Link to Source Code'}
+          variant="standard"
+          onChange={(element) => {
+            source.label = 'source';
+            source.url = element.target.value;
+          }}
+        />
+        <TextField
+          label={'Link to Live Demo'}
+          variant="standard"
+          onChange={(element) => {
+            demo.label = 'demo';
+            demo.url = element.target.value;
+          }}
+        />
+        <Button variant="outlined" onClick={onSubmit}>
+          Add Project
+        </Button>
+      </Stack>
+    </form>
+  );
+};
+
+export default Project;

--- a/components/create/Review.tsx
+++ b/components/create/Review.tsx
@@ -5,24 +5,28 @@ import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 import { Typography } from '@mui/material';
 import { useContext } from 'react';
 import { Divider } from '@mui/material';
+import { IPortfolio } from 'models/data/IPortfolio';
 
 const Review = () => {
   const { title, name, headshot, about, work, skills, projects, contact } =
     useContext(CreatePortfolioContext);
+  const portfolio = {
+    content: { title, name, headshot, about, work, skills, projects, contact },
+  } as IPortfolio;
   return (
     <div>
       <Typography variant="h3">Personal Information</Typography>
       <Divider sx={{ borderBottomWidth: 2 }} />
       <Stack direction="column">
-        <Typography>Title: {title}</Typography>
-        <Typography>Name: {name}</Typography>
-        <Typography>Photo: {headshot}</Typography>
-        <Typography>Summary: {about}</Typography>
+        <Typography>Title: {portfolio.content.title}</Typography>
+        <Typography>Name: {portfolio.content.name}</Typography>
+        <Typography>Photo: {portfolio.content.headshot}</Typography>
+        <Typography>Summary: {portfolio.content.about}</Typography>
       </Stack>
       <Typography variant="h3">Work History</Typography>
       <Divider sx={{ borderBottomWidth: 2 }} />
       <Stack direction="column">
-        {work?.map((job, index: number) => (
+        {portfolio.content.work?.map((job, index: number) => (
           <Stack key={index} spacing={1} sx={{ paddingBottom: 2 }}>
             <Typography>Position: {job.position}</Typography>
             <Typography>Company: {job.company}</Typography>
@@ -34,17 +38,17 @@ const Review = () => {
       <Typography variant="h3">Skills</Typography>
       <Divider sx={{ borderBottomWidth: 2 }} />
       <Typography>Tech Skills</Typography>
-      {skills.tech?.map((tech, index: number) => (
+      {portfolio.content.skills.tech?.map((tech, index: number) => (
         <Chip key={index} label={tech} />
       ))}
 
       <Typography paddingTop={2}>Soft Skills</Typography>
-      {skills.soft?.map((soft, index: number) => (
+      {portfolio.content.skills.soft?.map((soft, index: number) => (
         <Chip key={index} label={soft} />
       ))}
       <Typography variant="h3">Projects</Typography>
       <Divider sx={{ borderBottomWidth: 2 }} />
-      {projects?.map((project, index: number) => (
+      {portfolio.content.projects?.map((project, index: number) => (
         <Stack key={index} spacing={1} sx={{ paddingBottom: 2 }}>
           <Typography>Title: {project.title}</Typography>
           <Typography>Picture: {project.picture}</Typography>
@@ -60,8 +64,8 @@ const Review = () => {
       <Typography variant="h3">Contact Information</Typography>
       <Divider sx={{ borderBottomWidth: 2 }} />
       <Stack direction="column">
-        <Typography>Email: {contact.email}</Typography>
-        {contact.links?.map((link, index: number) => (
+        <Typography>Email: {portfolio.content.contact.email}</Typography>
+        {portfolio.content.contact.links?.map((link, index: number) => (
           <Typography key={index}>
             {link.label}: {link.url}
           </Typography>

--- a/components/create/Review.tsx
+++ b/components/create/Review.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
-import Chip from '@mui/material/Chip';
-import Stack from '@mui/material/Stack';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { Typography } from '@mui/material';
 import { useContext } from 'react';
-import { Divider } from '@mui/material';
 import { IPortfolio } from 'models/data/IPortfolio';
+import PortfolioView from 'components/view/PortfolioView';
 
 const Review = () => {
   const { title, name, headshot, about, work, skills, projects, contact } =
@@ -13,65 +10,7 @@ const Review = () => {
   const portfolio = {
     content: { title, name, headshot, about, work, skills, projects, contact },
   } as IPortfolio;
-  return (
-    <div>
-      <Typography variant="h3">Personal Information</Typography>
-      <Divider sx={{ borderBottomWidth: 2 }} />
-      <Stack direction="column">
-        <Typography>Title: {portfolio.content.title}</Typography>
-        <Typography>Name: {portfolio.content.name}</Typography>
-        <Typography>Photo: {portfolio.content.headshot}</Typography>
-        <Typography>Summary: {portfolio.content.about}</Typography>
-      </Stack>
-      <Typography variant="h3">Work History</Typography>
-      <Divider sx={{ borderBottomWidth: 2 }} />
-      <Stack direction="column">
-        {portfolio.content.work?.map((job, index: number) => (
-          <Stack key={index} spacing={1} sx={{ paddingBottom: 2 }}>
-            <Typography>Position: {job.position}</Typography>
-            <Typography>Company: {job.company}</Typography>
-            <Typography>Dates Worked: {job.dateWorked}</Typography>
-            <Typography>What you did: {job.description}</Typography>
-          </Stack>
-        ))}
-      </Stack>
-      <Typography variant="h3">Skills</Typography>
-      <Divider sx={{ borderBottomWidth: 2 }} />
-      <Typography>Tech Skills</Typography>
-      {portfolio.content.skills.tech?.map((tech, index: number) => (
-        <Chip key={index} label={tech} />
-      ))}
 
-      <Typography paddingTop={2}>Soft Skills</Typography>
-      {portfolio.content.skills.soft?.map((soft, index: number) => (
-        <Chip key={index} label={soft} />
-      ))}
-      <Typography variant="h3">Projects</Typography>
-      <Divider sx={{ borderBottomWidth: 2 }} />
-      {portfolio.content.projects?.map((project, index: number) => (
-        <Stack key={index} spacing={1} sx={{ paddingBottom: 2 }}>
-          <Typography>Title: {project.title}</Typography>
-          <Typography>Picture: {project.picture}</Typography>
-          <Typography>Summary: {project.summary}</Typography>
-          {project.links?.map((link, index: number) => (
-            <Stack key={index}>
-              <Typography>{link.label}</Typography>
-              <Typography>{link.url}</Typography>
-            </Stack>
-          ))}
-        </Stack>
-      ))}
-      <Typography variant="h3">Contact Information</Typography>
-      <Divider sx={{ borderBottomWidth: 2 }} />
-      <Stack direction="column">
-        <Typography>Email: {portfolio.content.contact.email}</Typography>
-        {portfolio.content.contact.links?.map((link, index: number) => (
-          <Typography key={index}>
-            {link.label}: {link.url}
-          </Typography>
-        ))}
-      </Stack>
-    </div>
-  );
+  return <PortfolioView portfolio={portfolio} />;
 };
 export default Review;

--- a/components/create/Review.tsx
+++ b/components/create/Review.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
+import { Typography } from '@mui/material';
+import { useState, useContext, useRef, RefObject } from 'react';
+import { Divider } from '@mui/material';
+
+const Review = () => {
+  const { title, name, headshot, about, work, skills, projects, contact } =
+    useContext(CreatePortfolioContext);
+  return (
+    <div>
+      <Typography variant="h3">Personal Information</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      <Stack direction="column">
+        <Typography>Title: {title}</Typography>
+        <Typography>Name: {name}</Typography>
+        <Typography>Photo: {headshot}</Typography>
+        <Typography>Summary: {about}</Typography>
+      </Stack>
+      <Typography variant="h3">Work History</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      <Stack direction="column">
+        {work?.map((job, index: number) => (
+          <Stack key={index} spacing={1} sx={{ paddingBottom: 2 }}>
+            <Typography>Position: {job.position}</Typography>
+            <Typography>Company: {job.company}</Typography>
+            <Typography>Dates Worked: {job.dateWorked}</Typography>
+            <Typography>What you did: {job.description}</Typography>
+          </Stack>
+        ))}
+      </Stack>
+      <Typography variant="h3">Skills</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      <Typography>Tech Skills</Typography>
+      {skills.tech?.map((tech, index: number) => (
+        <Chip key={index} label={tech} />
+      ))}
+
+      <Typography paddingTop={2}>Soft Skills</Typography>
+      {skills.soft?.map((soft, index: number) => (
+        <Chip key={index} label={soft} />
+      ))}
+      <Typography variant="h3">Projects</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      {projects?.map((project, index: number) => (
+        <Stack key={index} spacing={1} sx={{ paddingBottom: 2 }}>
+          <Typography>Title: {project.title}</Typography>
+          <Typography>Picture: {project.picture}</Typography>
+          <Typography>Summary: {project.summary}</Typography>
+          {project.links?.map((link, index: number) => (
+            <Stack key={index}>
+              <Typography>{link.label}</Typography>
+              <Typography>{link.url}</Typography>
+            </Stack>
+          ))}
+        </Stack>
+      ))}
+      <Typography variant="h3">Contact Information</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      <Stack direction="column">
+        <Typography>Email: {contact.email}</Typography>
+        {contact.links?.map((link, index: number) => (
+          <Typography key={index}>
+            {link.label}: {link.url}
+          </Typography>
+        ))}
+      </Stack>
+    </div>
+  );
+};
+export default Review;

--- a/components/create/Review.tsx
+++ b/components/create/Review.tsx
@@ -3,7 +3,7 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 import { Typography } from '@mui/material';
-import { useState, useContext, useRef, RefObject } from 'react';
+import { useContext } from 'react';
 import { Divider } from '@mui/material';
 
 const Review = () => {

--- a/components/create/Skills.tsx
+++ b/components/create/Skills.tsx
@@ -9,16 +9,10 @@ const Skills = () => {
   const [techSkill, setTechSkill] = useState('');
   const [softSkill, setSoftSkill] = useState('');
 
-  const handleClick = () => {
-    console.info('You clicked the Chip.');
-  };
-  const handleDelete = () => {
-    console.info('You clicked the delete icon.');
-  };
   return (
     <div>
       <StyledTextField
-        label={'Tech Skills'}
+        label="Tech Skills"
         value={techSkill}
         onChange={(event) => {
           setTechSkill(event.target.value);
@@ -33,16 +27,11 @@ const Skills = () => {
       />
       <Stack direction="row" spacing={1}>
         {skills.tech?.map((tech, index: number) => (
-          <Chip
-            key={index}
-            label={tech}
-            onClick={handleClick}
-            onDelete={handleDelete}
-          />
+          <Chip key={index} label={tech} />
         ))}
       </Stack>
       <StyledTextField
-        label={'Soft Skills'}
+        label="Soft Skills"
         value={softSkill}
         onChange={(event) => {
           setSoftSkill(event.target.value);
@@ -57,12 +46,7 @@ const Skills = () => {
       />
       <Stack direction="row" spacing={1}>
         {skills.soft?.map((soft, index: number) => (
-          <Chip
-            key={index}
-            label={soft}
-            onClick={handleClick}
-            onDelete={handleDelete}
-          />
+          <Chip key={index} label={soft} />
         ))}
       </Stack>
     </div>

--- a/components/create/Skills.tsx
+++ b/components/create/Skills.tsx
@@ -4,24 +4,30 @@ import Stack from '@mui/material/Stack';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 import { StyledTextField } from 'components/create/Styled';
 import { useState, useContext } from 'react';
+import { isUndefined } from 'utils';
 const Skills = () => {
   const { skills, setSkills } = useContext(CreatePortfolioContext);
-  const [techSkill, setTechSkill] = useState('');
-  const [softSkill, setSoftSkill] = useState('');
+  const [draftTechSkill, setDraftTechSkill] = useState('');
+  const [draftSoftSkill, setDraftSoftSkill] = useState('');
 
   return (
     <div>
       <StyledTextField
         label="Tech Skills"
-        value={techSkill}
+        value={draftTechSkill}
         onChange={(event) => {
-          setTechSkill(event.target.value);
+          setDraftTechSkill(event.target.value);
         }}
         onKeyPress={(e: any) => {
           if (e.key === 'Enter') {
-            skills.tech?.push(e.target.value);
-            setSkills({ ...skills });
-            setTechSkill('');
+            const newSkill = e.target.value;
+            setSkills({
+              ...skills,
+              tech: isUndefined(skills.tech)
+                ? [newSkill]
+                : [...(skills.tech as string[]), newSkill],
+            });
+            setDraftTechSkill('');
           }
         }}
       />
@@ -32,15 +38,20 @@ const Skills = () => {
       </Stack>
       <StyledTextField
         label="Soft Skills"
-        value={softSkill}
+        value={draftSoftSkill}
         onChange={(event) => {
-          setSoftSkill(event.target.value);
+          setDraftSoftSkill(event.target.value);
         }}
         onKeyPress={(e: any) => {
           if (e.key === 'Enter') {
-            skills.soft?.push(e.target.value);
-            setSkills({ ...skills });
-            setSoftSkill('');
+            const newSkill = e.target.value;
+            setSkills({
+              ...skills,
+              soft: isUndefined(skills.soft)
+                ? [newSkill]
+                : [...(skills.soft as string[]), newSkill],
+            });
+            setDraftSoftSkill('');
           }
         }}
       />

--- a/components/create/Skills.tsx
+++ b/components/create/Skills.tsx
@@ -2,16 +2,13 @@ import * as React from 'react';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import {
-  StyledTextField,
-  StyledParagraphTextField,
-} from 'components/create/Styled';
-import { useState, useContext, useRef, RefObject } from 'react';
+import { StyledTextField } from 'components/create/Styled';
+import { useState, useContext } from 'react';
 const Skills = () => {
   const { skills, setSkills } = useContext(CreatePortfolioContext);
   const [techSkill, setTechSkill] = useState('');
   const [softSkill, setSoftSkill] = useState('');
-  const formRef = useRef() as RefObject<HTMLFormElement>;
+
   const handleClick = () => {
     console.info('You clicked the Chip.');
   };

--- a/components/create/Skills.tsx
+++ b/components/create/Skills.tsx
@@ -2,12 +2,16 @@ import * as React from 'react';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { TextField, Input } from '@mui/material';
-import { useCallback, useState, useContext } from 'react';
-import { ISkills } from 'models/data/';
-import { prepareDataForValidation } from 'formik';
+import {
+  StyledTextField,
+  StyledParagraphTextField,
+} from 'components/create/Styled';
+import { useState, useContext, useRef, RefObject } from 'react';
 const Skills = () => {
   const { skills, setSkills } = useContext(CreatePortfolioContext);
+  const [techSkill, setTechSkill] = useState('');
+  const [softSkill, setSoftSkill] = useState('');
+  const formRef = useRef() as RefObject<HTMLFormElement>;
   const handleClick = () => {
     console.info('You clicked the Chip.');
   };
@@ -16,13 +20,17 @@ const Skills = () => {
   };
   return (
     <div>
-      <TextField
+      <StyledTextField
         label={'Tech Skills'}
-        variant="standard"
+        value={techSkill}
+        onChange={(event) => {
+          setTechSkill(event.target.value);
+        }}
         onKeyPress={(e: any) => {
           if (e.key === 'Enter') {
             skills.tech?.push(e.target.value);
             setSkills({ ...skills });
+            setTechSkill('');
           }
         }}
       />
@@ -36,13 +44,17 @@ const Skills = () => {
           />
         ))}
       </Stack>
-      <TextField
+      <StyledTextField
         label={'Soft Skills'}
-        variant="standard"
+        value={softSkill}
+        onChange={(event) => {
+          setSoftSkill(event.target.value);
+        }}
         onKeyPress={(e: any) => {
           if (e.key === 'Enter') {
             skills.soft?.push(e.target.value);
             setSkills({ ...skills });
+            setSoftSkill('');
           }
         }}
       />

--- a/components/create/Skills.tsx
+++ b/components/create/Skills.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
+import { TextField, Input } from '@mui/material';
+import { useCallback, useState, useContext } from 'react';
+import { ISkills } from 'models/data/';
+import { prepareDataForValidation } from 'formik';
+const Skills = () => {
+  const { skills, setSkills } = useContext(CreatePortfolioContext);
+  const handleClick = () => {
+    console.info('You clicked the Chip.');
+  };
+  const handleDelete = () => {
+    console.info('You clicked the delete icon.');
+  };
+  return (
+    <div>
+      <TextField
+        label={'Tech Skills'}
+        variant="standard"
+        onKeyPress={(e: any) => {
+          if (e.key === 'Enter') {
+            skills.tech?.push(e.target.value);
+            setSkills({ ...skills });
+          }
+        }}
+      />
+      <Stack direction="row" spacing={1}>
+        {skills.tech?.map((tech, index: number) => (
+          <Chip
+            key={index}
+            label={tech}
+            onClick={handleClick}
+            onDelete={handleDelete}
+          />
+        ))}
+      </Stack>
+      <TextField
+        label={'Soft Skills'}
+        variant="standard"
+        onKeyPress={(e: any) => {
+          if (e.key === 'Enter') {
+            skills.soft?.push(e.target.value);
+            setSkills({ ...skills });
+          }
+        }}
+      />
+      <Stack direction="row" spacing={1}>
+        {skills.soft?.map((soft, index: number) => (
+          <Chip
+            key={index}
+            label={soft}
+            onClick={handleClick}
+            onDelete={handleDelete}
+          />
+        ))}
+      </Stack>
+    </div>
+  );
+};
+
+export default Skills;

--- a/components/create/Styled.tsx
+++ b/components/create/Styled.tsx
@@ -1,0 +1,19 @@
+import { styled } from '@mui/system';
+import { Button, TextField } from '@mui/material';
+
+export const StyledTextField = styled(TextField, {
+  name: 'StyledTextField',
+})({
+  width: 300,
+  padding: 4,
+});
+export const StyledParagraphTextField = styled(TextField, {
+  name: 'StyledParagraphTextField',
+})({
+  width: 300,
+});
+export const StyledButton = styled(Button, {
+  name: 'StyledButton',
+})({
+  width: 300,
+});

--- a/components/create/WorkHistory.tsx
+++ b/components/create/WorkHistory.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { TextField, Input, Stack, Button } from '@mui/material';
-import { useCallback, useState, useContext, useRef, RefObject } from 'react';
-import { IWorkHistory } from 'models/data/';
-
+import { Stack, Button } from '@mui/material';
+import { useContext, useRef, RefObject } from 'react';
+import { StyledTextField, StyledButton } from 'components/create/Styled';
 const WorkHistory = () => {
   const formRef = useRef() as RefObject<HTMLFormElement>;
   const entry = {
@@ -13,10 +12,6 @@ const WorkHistory = () => {
     description: '',
   };
   const { work, setWork } = useContext(CreatePortfolioContext);
-  // const [position, setPosition] = useState('');
-  // const [company, setCompany] = useState('');
-  // const [dateWorked, setDateWorked] = useState('');
-  // const [description, setDescription] = useState('');
   const onSubmit = async () => {
     work.push(entry);
     setWork([...work]);
@@ -25,37 +20,35 @@ const WorkHistory = () => {
   return (
     <form ref={formRef}>
       <Stack direction="column" spacing={1}>
-        <TextField
+        <StyledTextField
           label={'Position'}
-          variant="standard"
           onChange={(element) => {
             entry.position = element.target.value;
           }}
         />
-        <TextField
+        <StyledTextField
           label={'Company'}
-          variant="standard"
           onChange={(element) => {
             entry.company = element.target.value;
           }}
         />
-        <TextField
+        <StyledTextField
           label={'Interval of employement'}
-          variant="standard"
           onChange={(element) => {
             entry.dateWorked = element.target.value;
           }}
         />
-        <TextField
-          label={'Job Description'}
-          variant="standard"
+        <StyledTextField
+          label={'Summary of what you did'}
+          multiline
+          rows={4}
           onChange={(element) => {
             entry.description = element.target.value;
           }}
         />
-        <Button variant="outlined" onClick={onSubmit}>
+        <StyledButton variant="outlined" onClick={onSubmit}>
           Add Work History
-        </Button>
+        </StyledButton>
       </Stack>
     </form>
   );

--- a/components/create/WorkHistory.tsx
+++ b/components/create/WorkHistory.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
+import { TextField, Input, Stack } from '@mui/material';
+import { useCallback, useState, useContext } from 'react';
+import { IWorkHistory } from 'models/data/';
+
+const WorkHistory = () => {
+  const { work, setWork } = useContext(CreatePortfolioContext);
+  return (
+    <div>
+      {work.map((entry: any, index: number) => (
+        <Stack direction="row" spacing={1} key={-1}>
+          <TextField
+            label={'Position'}
+            variant="standard"
+            onKeyPress={(e: any) => {
+              if (e.key === 'Enter') {
+                entry.position = e.target.value;
+              }
+            }}
+          />
+          <TextField
+            label={'Company'}
+            variant="standard"
+            onKeyPress={(e: any) => {
+              if (e.key === 'Enter') {
+                entry.company = e.target.value;
+              }
+            }}
+          />
+          <TextField
+            label={'Interval of employement'}
+            variant="standard"
+            onKeyPress={(e: any) => {
+              if (e.key === 'Enter') {
+                entry.dateWorked = e.target.value;
+              }
+            }}
+          />
+          <TextField
+            label={'Job Description'}
+            variant="standard"
+            onKeyPress={(e: any) => {
+              if (e.key === 'Enter') {
+                entry.description = e.target.value;
+                setWork([...work]);
+              }
+            }}
+          />
+        </Stack>
+      ))}
+    </div>
+  );
+};
+
+export default WorkHistory;

--- a/components/create/WorkHistory.tsx
+++ b/components/create/WorkHistory.tsx
@@ -12,7 +12,7 @@ const WorkHistory = () => {
     description: '',
   };
   const { work, setWork } = useContext(CreatePortfolioContext);
-  const onSubmit = async () => {
+  const onSubmit = () => {
     work.push(entry);
     setWork([...work]);
     formRef.current?.reset();
@@ -21,25 +21,25 @@ const WorkHistory = () => {
     <form ref={formRef}>
       <Stack direction="column" spacing={1}>
         <StyledTextField
-          label={'Position'}
+          label="Position"
           onChange={(element) => {
             entry.position = element.target.value;
           }}
         />
         <StyledTextField
-          label={'Company'}
+          label="Company"
           onChange={(element) => {
             entry.company = element.target.value;
           }}
         />
         <StyledTextField
-          label={'Interval of employement'}
+          label="Interval of employement"
           onChange={(element) => {
             entry.dateWorked = element.target.value;
           }}
         />
         <StyledTextField
-          label={'Summary of what you did'}
+          label="Summary of what you did"
           multiline
           rows={4}
           onChange={(element) => {

--- a/components/create/WorkHistory.tsx
+++ b/components/create/WorkHistory.tsx
@@ -1,55 +1,63 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { TextField, Input, Stack } from '@mui/material';
-import { useCallback, useState, useContext } from 'react';
+import { TextField, Input, Stack, Button } from '@mui/material';
+import { useCallback, useState, useContext, useRef, RefObject } from 'react';
 import { IWorkHistory } from 'models/data/';
 
 const WorkHistory = () => {
+  const formRef = useRef() as RefObject<HTMLFormElement>;
+  const entry = {
+    position: '',
+    company: '',
+    dateWorked: '',
+    description: '',
+  };
   const { work, setWork } = useContext(CreatePortfolioContext);
+  // const [position, setPosition] = useState('');
+  // const [company, setCompany] = useState('');
+  // const [dateWorked, setDateWorked] = useState('');
+  // const [description, setDescription] = useState('');
+  const onSubmit = async () => {
+    work.push(entry);
+    setWork([...work]);
+    formRef.current?.reset();
+  };
   return (
-    <div>
-      {work.map((entry: any, index: number) => (
-        <Stack direction="row" spacing={1} key={-1}>
-          <TextField
-            label={'Position'}
-            variant="standard"
-            onKeyPress={(e: any) => {
-              if (e.key === 'Enter') {
-                entry.position = e.target.value;
-              }
-            }}
-          />
-          <TextField
-            label={'Company'}
-            variant="standard"
-            onKeyPress={(e: any) => {
-              if (e.key === 'Enter') {
-                entry.company = e.target.value;
-              }
-            }}
-          />
-          <TextField
-            label={'Interval of employement'}
-            variant="standard"
-            onKeyPress={(e: any) => {
-              if (e.key === 'Enter') {
-                entry.dateWorked = e.target.value;
-              }
-            }}
-          />
-          <TextField
-            label={'Job Description'}
-            variant="standard"
-            onKeyPress={(e: any) => {
-              if (e.key === 'Enter') {
-                entry.description = e.target.value;
-                setWork([...work]);
-              }
-            }}
-          />
-        </Stack>
-      ))}
-    </div>
+    <form ref={formRef}>
+      <Stack direction="column" spacing={1}>
+        <TextField
+          label={'Position'}
+          variant="standard"
+          onChange={(element) => {
+            entry.position = element.target.value;
+          }}
+        />
+        <TextField
+          label={'Company'}
+          variant="standard"
+          onChange={(element) => {
+            entry.company = element.target.value;
+          }}
+        />
+        <TextField
+          label={'Interval of employement'}
+          variant="standard"
+          onChange={(element) => {
+            entry.dateWorked = element.target.value;
+          }}
+        />
+        <TextField
+          label={'Job Description'}
+          variant="standard"
+          onChange={(element) => {
+            entry.description = element.target.value;
+          }}
+        />
+        <Button variant="outlined" onClick={onSubmit}>
+          Add Work History
+        </Button>
+      </Stack>
+    </form>
   );
 };
 

--- a/components/create/WorkHistory.tsx
+++ b/components/create/WorkHistory.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
-import { Stack, Button } from '@mui/material';
+import { Stack } from '@mui/material';
 import { useContext, useRef, RefObject } from 'react';
 import { StyledTextField, StyledButton } from 'components/create/Styled';
 const WorkHistory = () => {

--- a/components/create/WorkHistory.tsx
+++ b/components/create/WorkHistory.tsx
@@ -1,56 +1,74 @@
 import * as React from 'react';
 import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 import { Stack } from '@mui/material';
-import { useContext, useRef, RefObject } from 'react';
+import { useContext, useState } from 'react';
 import { StyledTextField, StyledButton } from 'components/create/Styled';
+import { IWorkHistory } from 'models/data/';
 const WorkHistory = () => {
-  const formRef = useRef() as RefObject<HTMLFormElement>;
-  const entry = {
+  const [draftEntry, setDraftEntry] = useState<IWorkHistory>({
     position: '',
     company: '',
     dateWorked: '',
     description: '',
-  };
+  });
   const { work, setWork } = useContext(CreatePortfolioContext);
   const onSubmit = () => {
-    work.push(entry);
-    setWork([...work]);
-    formRef.current?.reset();
+    setWork([...work, draftEntry]);
+    setDraftEntry({
+      position: '',
+      company: '',
+      dateWorked: '',
+      description: '',
+    });
   };
   return (
-    <form ref={formRef}>
-      <Stack direction="column" spacing={1}>
-        <StyledTextField
-          label="Position"
-          onChange={(element) => {
-            entry.position = element.target.value;
-          }}
-        />
-        <StyledTextField
-          label="Company"
-          onChange={(element) => {
-            entry.company = element.target.value;
-          }}
-        />
-        <StyledTextField
-          label="Interval of employement"
-          onChange={(element) => {
-            entry.dateWorked = element.target.value;
-          }}
-        />
-        <StyledTextField
-          label="Summary of what you did"
-          multiline
-          rows={4}
-          onChange={(element) => {
-            entry.description = element.target.value;
-          }}
-        />
-        <StyledButton variant="outlined" onClick={onSubmit}>
-          Add Work History
-        </StyledButton>
-      </Stack>
-    </form>
+    <Stack direction="column" spacing={1}>
+      <StyledTextField
+        label="Position"
+        onChange={(element) => {
+          setDraftEntry({
+            ...draftEntry,
+            position: element.target.value,
+          });
+        }}
+        value={draftEntry.position}
+      />
+      <StyledTextField
+        label="Company"
+        onChange={(element) => {
+          setDraftEntry({
+            ...draftEntry,
+            company: element.target.value,
+          });
+        }}
+        value={draftEntry.company}
+      />
+      <StyledTextField
+        label="Interval of employement"
+        onChange={(element) => {
+          setDraftEntry({
+            ...draftEntry,
+            dateWorked: element.target.value,
+          });
+        }}
+        value={draftEntry.dateWorked}
+      />
+      <StyledTextField
+        label="Summary of what you did"
+        multiline
+        rows={4}
+        onChange={(element) => {
+          setDraftEntry({
+            ...draftEntry,
+            description: element.target.value,
+          });
+        }}
+        value={draftEntry.description}
+      />
+      <StyledButton variant="outlined" onClick={onSubmit}>
+        Add Work History
+      </StyledButton>
+    </Stack>
   );
 };
 

--- a/components/create/common/LinksEditor.tsx
+++ b/components/create/common/LinksEditor.tsx
@@ -1,0 +1,95 @@
+import { Button, Stack } from '@mui/material';
+import { ILink } from 'models/data';
+import { useMemo } from 'react';
+import { StyledTextField, StyledButton } from 'components/create/Styled';
+
+type LinksEditorProps = {
+  links: ILink[];
+  setLinks: (newLinks: ILink[]) => void;
+};
+
+/**
+ * LinksEditor component allows users to add, remove, and edit
+ * @param props
+ * @returns
+ */
+const LinksEditor = (props: LinksEditorProps) => {
+  const { links, setLinks } = props;
+  const lastLink = useMemo(() => links[links.length - 1], [links]);
+
+  // Can only add link if last link is filled in
+  const addButtonEnabled = useMemo(
+    () => !lastLink || (lastLink.label !== '' && lastLink.url !== ''),
+    [lastLink]
+  );
+
+  const onAddLink = () => {
+    setLinks([
+      ...links,
+      {
+        label: '',
+        url: '',
+      },
+    ]);
+  };
+
+  const onRemoveLink = (removeIndex: number) => {
+    const newLinks = links.filter((link, index) => index !== removeIndex);
+    setLinks(newLinks);
+  };
+
+  const onChangeLinkLabel = (updateIndex: number, newLabel: string) => {
+    const newLinks = links.map((link, index) =>
+      index === updateIndex ? { ...link, label: newLabel } : link
+    );
+    setLinks(newLinks);
+  };
+
+  const onChangeLinkUrl = (updateIndex: number, newUrl: string) => {
+    const newLinks = links.map((link, index) =>
+      index === updateIndex ? { ...link, url: newUrl } : link
+    );
+    setLinks(newLinks);
+  };
+
+  return (
+    <div>
+      <Stack direction="column">
+        {links.map((link, index) => {
+          return (
+            <Stack direction="row" key={index}>
+              <StyledTextField
+                label={'Label'}
+                onChange={(element) => {
+                  onChangeLinkLabel(index, element.target.value);
+                }}
+                value={links[index].label}
+              />
+              <StyledTextField
+                label={'URL'}
+                onChange={(element) => {
+                  onChangeLinkUrl(index, element.target.value);
+                }}
+                value={links[index].url}
+              />
+              <StyledButton variant="text" onClick={() => onRemoveLink(index)}>
+                Remove Link
+              </StyledButton>
+            </Stack>
+          );
+        })}
+
+        <StyledButton
+          variant="outlined"
+          onClick={() => onAddLink()}
+          disabled={!addButtonEnabled}
+          style={{ maxWidth: '595px' }}
+        >
+          Add Link
+        </StyledButton>
+      </Stack>
+    </div>
+  );
+};
+
+export default LinksEditor;

--- a/components/create/common/LinksEditor.tsx
+++ b/components/create/common/LinksEditor.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack } from '@mui/material';
+import { Stack } from '@mui/material';
 import { ILink } from 'models/data';
 import { useMemo } from 'react';
 import { StyledTextField, StyledButton } from 'components/create/Styled';

--- a/components/create/common/LinksEditor.tsx
+++ b/components/create/common/LinksEditor.tsx
@@ -23,6 +23,7 @@ const LinksEditor = (props: LinksEditorProps) => {
     [lastLink]
   );
 
+  const isValidUrl = (url: string) => url.startsWith('https://');
   const onAddLink = () => {
     setLinks([
       ...links,
@@ -59,18 +60,19 @@ const LinksEditor = (props: LinksEditorProps) => {
           return (
             <Stack direction="row" key={index}>
               <StyledTextField
-                label={'Label'}
+                label="Label"
                 onChange={(element) => {
                   onChangeLinkLabel(index, element.target.value);
                 }}
                 value={links[index].label}
               />
               <StyledTextField
-                label={'URL'}
+                label="URL (include https://)"
                 onChange={(element) => {
                   onChangeLinkUrl(index, element.target.value);
                 }}
                 value={links[index].url}
+                error={!isValidUrl(links[index].url)}
               />
               <StyledButton variant="text" onClick={() => onRemoveLink(index)}>
                 Remove Link

--- a/components/view/PortfolioView.tsx
+++ b/components/view/PortfolioView.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import { Typography } from '@mui/material';
+import { Divider } from '@mui/material';
+import { IPortfolio } from 'models/data/IPortfolio';
+
+type PortfolioViewProps = {
+  portfolio: IPortfolio;
+};
+
+const PortfolioView = (props: PortfolioViewProps) => {
+  const { portfolio } = props;
+
+  return (
+    <div>
+      <Typography variant="h3">Personal Information</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      <Stack direction="column">
+        <Typography>Title: {portfolio.content.title}</Typography>
+        <Typography>Name: {portfolio.content.name}</Typography>
+        <Typography>Photo: {portfolio.content.headshot}</Typography>
+        <Typography>Summary: {portfolio.content.about}</Typography>
+      </Stack>
+      <Typography variant="h3">Work History</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      <Stack direction="column">
+        {portfolio.content.work?.map((job, index: number) => (
+          <Stack key={index} spacing={1} sx={{ paddingBottom: 2 }}>
+            <Typography>Position: {job.position}</Typography>
+            <Typography>Company: {job.company}</Typography>
+            <Typography>Dates Worked: {job.dateWorked}</Typography>
+            <Typography>What you did: {job.description}</Typography>
+          </Stack>
+        ))}
+      </Stack>
+      <Typography variant="h3">Skills</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      <Typography>Tech Skills</Typography>
+      {portfolio.content.skills.tech?.map((tech, index: number) => (
+        <Chip key={index} label={tech} />
+      ))}
+
+      <Typography paddingTop={2}>Soft Skills</Typography>
+      {portfolio.content.skills.soft?.map((soft, index: number) => (
+        <Chip key={index} label={soft} />
+      ))}
+      <Typography variant="h3">Projects</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      {portfolio.content.projects?.map((project, index: number) => (
+        <Stack key={index} spacing={1} sx={{ paddingBottom: 2 }}>
+          <Typography>Title: {project.title}</Typography>
+          <Typography>Picture: {project.picture}</Typography>
+          <Typography>Summary: {project.summary}</Typography>
+          {project.links?.map((link, index: number) => (
+            <Stack key={index}>
+              <Typography>{link.label}</Typography>
+              <Typography>{link.url}</Typography>
+            </Stack>
+          ))}
+        </Stack>
+      ))}
+      <Typography variant="h3">Contact Information</Typography>
+      <Divider sx={{ borderBottomWidth: 2 }} />
+      <Stack direction="column">
+        <Typography>Email: {portfolio.content.contact.email}</Typography>
+        {portfolio.content.contact.links?.map((link, index: number) => (
+          <Typography key={index}>
+            {link.label}: {link.url}
+          </Typography>
+        ))}
+      </Stack>
+    </div>
+  );
+};
+export default PortfolioView;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.9.3",
         "@mui/material": "^5.8.6",
         "aws-sdk": "^2.1165.0",
+        "formik": "^2.2.9",
         "next": "12.2.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -1806,6 +1807,14 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -2513,6 +2522,34 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
+    "node_modules/formik": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz",
+      "integrity": "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://opencollective.com/formik"
+        }
+      ],
+      "dependencies": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/formik/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3141,6 +3178,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3636,6 +3683,11 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -3987,6 +4039,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -5450,6 +5507,11 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+    },
     "define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -6011,6 +6073,27 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
+    "formik": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz",
+      "integrity": "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==",
+      "requires": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6465,6 +6548,16 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6804,6 +6897,11 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7039,6 +7137,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
+        "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.8.6",
         "aws-sdk": "^2.1165.0",
         "formik": "^2.2.9",
@@ -735,6 +736,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.4.tgz",
+      "integrity": "sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@mui/material": {
       "version": "5.8.6",
@@ -4842,6 +4868,14 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         }
+      }
+    },
+    "@mui/icons-material": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.4.tgz",
+      "integrity": "sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "@mui/material": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.9.3",
     "@mui/material": "^5.8.6",
     "aws-sdk": "^2.1165.0",
+    "formik": "^2.2.9",
     "next": "12.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.6",
     "aws-sdk": "^2.1165.0",
     "formik": "^2.2.9",

--- a/pages/portfolio/[id].tsx
+++ b/pages/portfolio/[id].tsx
@@ -1,4 +1,5 @@
-import { CircularProgress, Typography } from '@mui/material';
+import { CircularProgress } from '@mui/material';
+import PortfolioView from 'components/view/PortfolioView';
 import { IPortfolio } from 'models/data';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
@@ -23,17 +24,7 @@ const PortfolioDetailPage: NextPage = () => {
     return <CircularProgress />;
   }
 
-  return (
-    <div>
-      <Typography variant="h1">{portfolio.content.title}</Typography>
-      <Typography variant="subtitle1">
-        Created {portfolio.meta.createTime}
-      </Typography>
-      <Typography variant="subtitle1">
-        Last modified {portfolio.meta.modifyTime}
-      </Typography>
-    </div>
-  );
+  return <PortfolioView portfolio={portfolio} />;
 };
 
 export default PortfolioDetailPage;

--- a/pages/portfolio/create.tsx
+++ b/pages/portfolio/create.tsx
@@ -12,6 +12,7 @@ import Contact from 'components/create/Contact';
 //import {Skills, Introduction, WorkHistory, Contact, Project} from 'components/create';
 import Project from 'components/create/Project';
 import { stringify } from 'querystring';
+import Review from 'components/create/Review';
 const CreatePortfolioPage: NextPage = () => {
   const portfolioClient = new PortfolioApiClient();
   const router = useRouter();
@@ -63,10 +64,24 @@ const CreatePortfolioPage: NextPage = () => {
       return <Skills />;
     } else if (page === 3) {
       return <Project />;
-    } else {
+    } else if (page === 4) {
       return <Contact />;
+    } else {
+      return (
+        <div>
+          <Review />
+          <Button
+            variant="contained"
+            disabled={isSubmitting}
+            onClick={onSubmit}
+          >
+            {isSubmitting ? 'Submitting...' : 'Create'}
+          </Button>
+        </div>
+      );
     }
   };
+  console.log(title);
   return (
     <CreatePortfolioContext.Provider
       value={{
@@ -89,32 +104,28 @@ const CreatePortfolioPage: NextPage = () => {
       }}
     >
       <div>
-        <Typography>{pageTitles[page]}</Typography>
+        <Typography variant="h3">{pageTitles[page]}</Typography>
       </div>
-      {/* <Introduction />
-      <WorkHistory />
-      <Skills />
-      <Project />
-      <Contact /> */}
       <div>{PageDisplay()}</div>
-      <button
+      <Button
+        variant="outlined"
+        color="secondary"
         disabled={page == 0}
         onClick={() => {
           setPage((currPage) => currPage - 1);
         }}
       >
         Prev
-      </button>
-      <button
-        disabled={page == 4}
+      </Button>
+      <Button
+        variant="outlined"
+        color="primary"
+        disabled={page == 5}
         onClick={() => {
           setPage((currPage) => currPage + 1);
         }}
       >
         Next
-      </button>
-      <Button variant="outlined" disabled={isSubmitting} onClick={onSubmit}>
-        {isSubmitting ? 'Submitting...' : 'Create'}
       </Button>
     </CreatePortfolioContext.Provider>
   );

--- a/pages/portfolio/create.tsx
+++ b/pages/portfolio/create.tsx
@@ -1,34 +1,32 @@
-import {
-  Button,
-  CircularProgress,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Button, CircularProgress, Typography, Grid } from '@mui/material';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { PortfolioApiClient } from 'utils/clients';
-
+import Introduction from 'components/create/Introduction';
+import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
+import { IWorkHistory, ISkills, IProject, IContact } from 'models/data/';
+import Skills from 'components/create/Skills';
+import WorkHistory from 'components/create/WorkHistory';
+import { stringify } from 'querystring';
 const CreatePortfolioPage: NextPage = () => {
   const portfolioClient = new PortfolioApiClient();
   const router = useRouter();
-
   const [title, setTitle] = useState('');
   const [name, setName] = useState('');
   const [headshot, setHeadShot] = useState('');
   const [about, setAbout] = useState('');
-  const [work, setWork] = useState([]);
-  const [skills, setSkills] = useState({});
-  const [projects, setProjects] = useState([]);
-  const [contact, setContact] = useState({});
-
+  const [work, setWork] = useState<IWorkHistory[]>([
+    { position: '', company: '', dateWorked: '', description: '' },
+  ]);
+  const [skills, setSkills] = useState<ISkills>({ tech: [], soft: [] });
+  const [projects, setProjects] = useState<IProject[]>([]);
+  const [contact, setContact] = useState<IContact>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
-
   if (isSubmitting) {
     return <CircularProgress />;
   }
-
+  //
   const onSubmit = async () => {
     setIsSubmitting(true);
     const portfolio = await portfolioClient.put({
@@ -42,24 +40,40 @@ const CreatePortfolioPage: NextPage = () => {
         projects,
         contact,
       },
+      //
     });
-    router.push(`/portfolio/${portfolio.id}`);
+    router.push(`/portfolio/${portfolio?.id}`);
   };
-
+  console.log(work[0]);
   return (
-    <div>
-      <Typography variant="h1">Create Portfolio</Typography>
-      <Stack spacing={2}>
-        <TextField
-          label="Title"
-          variant="standard"
-          onChange={(event) => setTitle(event.target.value)}
-        />
-        <Button variant="outlined" disabled={isSubmitting} onClick={onSubmit}>
-          {isSubmitting ? 'Submitting...' : 'Create'}
-        </Button>
-      </Stack>
-    </div>
+    <CreatePortfolioContext.Provider
+      value={{
+        title,
+        setTitle,
+        name,
+        setName,
+        headshot,
+        setHeadShot,
+        about,
+        setAbout,
+        work,
+        setWork,
+        skills,
+        setSkills,
+        projects,
+        setProjects,
+        contact,
+        setContact,
+      }}
+    >
+      <WorkHistory />
+      {/* <Introduction /> */}
+      {/* <Skills /> */}
+
+      <Button variant="outlined" disabled={isSubmitting} onClick={onSubmit}>
+        {isSubmitting ? 'Submitting...' : 'Create'}
+      </Button>
+    </CreatePortfolioContext.Provider>
   );
 };
 

--- a/pages/portfolio/create.tsx
+++ b/pages/portfolio/create.tsx
@@ -8,6 +8,7 @@ import CreatePortfolioContext from 'components/create/CreatePorfolioContext';
 import { IWorkHistory, ISkills, IProject, IContact } from 'models/data/';
 import Skills from 'components/create/Skills';
 import WorkHistory from 'components/create/WorkHistory';
+import Contact from 'components/create/Contact';
 import { stringify } from 'querystring';
 const CreatePortfolioPage: NextPage = () => {
   const portfolioClient = new PortfolioApiClient();
@@ -16,12 +17,10 @@ const CreatePortfolioPage: NextPage = () => {
   const [name, setName] = useState('');
   const [headshot, setHeadShot] = useState('');
   const [about, setAbout] = useState('');
-  const [work, setWork] = useState<IWorkHistory[]>([
-    { position: '', company: '', dateWorked: '', description: '' },
-  ]);
+  const [work, setWork] = useState<IWorkHistory[]>([]);
   const [skills, setSkills] = useState<ISkills>({ tech: [], soft: [] });
   const [projects, setProjects] = useState<IProject[]>([]);
-  const [contact, setContact] = useState<IContact>({});
+  const [contact, setContact] = useState<IContact>({ email: '', links: [] });
   const [isSubmitting, setIsSubmitting] = useState(false);
   if (isSubmitting) {
     return <CircularProgress />;
@@ -44,7 +43,7 @@ const CreatePortfolioPage: NextPage = () => {
     });
     router.push(`/portfolio/${portfolio?.id}`);
   };
-  console.log(work[0]);
+  console.log(contact);
   return (
     <CreatePortfolioContext.Provider
       value={{
@@ -66,7 +65,8 @@ const CreatePortfolioPage: NextPage = () => {
         setContact,
       }}
     >
-      <WorkHistory />
+      {/* <WorkHistory /> */}
+      <Contact />
       {/* <Introduction /> */}
       {/* <Skills /> */}
 

--- a/pages/portfolio/create.tsx
+++ b/pages/portfolio/create.tsx
@@ -1,4 +1,4 @@
-import { Button, CircularProgress, Typography, Grid } from '@mui/material';
+import { Button, CircularProgress, Typography } from '@mui/material';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
@@ -49,7 +49,6 @@ const CreatePortfolioPage: NextPage = () => {
       },
     });
     router.push(`/portfolio/${portfolio?.id}`);
-    console.log(portfolio);
   };
 
   const PageDisplay = () => {

--- a/pages/portfolio/create.tsx
+++ b/pages/portfolio/create.tsx
@@ -15,6 +15,7 @@ import { stringify } from 'querystring';
 const CreatePortfolioPage: NextPage = () => {
   const portfolioClient = new PortfolioApiClient();
   const router = useRouter();
+  const [page, setPage] = useState(0);
   const [title, setTitle] = useState('');
   const [name, setName] = useState('');
   const [headshot, setHeadShot] = useState('');
@@ -44,8 +45,28 @@ const CreatePortfolioPage: NextPage = () => {
       //
     });
     router.push(`/portfolio/${portfolio?.id}`);
+    console.log(portfolio);
   };
-  console.log(projects);
+  const pageTitles = [
+    'Personal Information',
+    'Work History',
+    'Skills',
+    'Projects',
+    'Contact Information',
+  ];
+  const PageDisplay = () => {
+    if (page === 0) {
+      return <Introduction />;
+    } else if (page === 1) {
+      return <WorkHistory />;
+    } else if (page === 2) {
+      return <Skills />;
+    } else if (page === 3) {
+      return <Project />;
+    } else {
+      return <Contact />;
+    }
+  };
   return (
     <CreatePortfolioContext.Provider
       value={{
@@ -67,12 +88,31 @@ const CreatePortfolioPage: NextPage = () => {
         setContact,
       }}
     >
-      <Introduction />
+      <div>
+        <Typography>{pageTitles[page]}</Typography>
+      </div>
+      {/* <Introduction />
       <WorkHistory />
       <Skills />
       <Project />
-      <Contact />
-
+      <Contact /> */}
+      <div>{PageDisplay()}</div>
+      <button
+        disabled={page == 0}
+        onClick={() => {
+          setPage((currPage) => currPage - 1);
+        }}
+      >
+        Prev
+      </button>
+      <button
+        disabled={page == 4}
+        onClick={() => {
+          setPage((currPage) => currPage + 1);
+        }}
+      >
+        Next
+      </button>
       <Button variant="outlined" disabled={isSubmitting} onClick={onSubmit}>
         {isSubmitting ? 'Submitting...' : 'Create'}
       </Button>

--- a/pages/portfolio/create.tsx
+++ b/pages/portfolio/create.tsx
@@ -9,6 +9,8 @@ import { IWorkHistory, ISkills, IProject, IContact } from 'models/data/';
 import Skills from 'components/create/Skills';
 import WorkHistory from 'components/create/WorkHistory';
 import Contact from 'components/create/Contact';
+//import {Skills, Introduction, WorkHistory, Contact, Project} from 'components/create';
+import Project from 'components/create/Project';
 import { stringify } from 'querystring';
 const CreatePortfolioPage: NextPage = () => {
   const portfolioClient = new PortfolioApiClient();
@@ -43,7 +45,7 @@ const CreatePortfolioPage: NextPage = () => {
     });
     router.push(`/portfolio/${portfolio?.id}`);
   };
-  console.log(contact);
+  console.log(projects);
   return (
     <CreatePortfolioContext.Provider
       value={{
@@ -65,10 +67,11 @@ const CreatePortfolioPage: NextPage = () => {
         setContact,
       }}
     >
-      {/* <WorkHistory /> */}
+      <Introduction />
+      <WorkHistory />
+      <Skills />
+      <Project />
       <Contact />
-      {/* <Introduction /> */}
-      {/* <Skills /> */}
 
       <Button variant="outlined" disabled={isSubmitting} onClick={onSubmit}>
         {isSubmitting ? 'Submitting...' : 'Create'}

--- a/pages/portfolio/create.tsx
+++ b/pages/portfolio/create.tsx
@@ -9,10 +9,15 @@ import { IWorkHistory, ISkills, IProject, IContact } from 'models/data/';
 import Skills from 'components/create/Skills';
 import WorkHistory from 'components/create/WorkHistory';
 import Contact from 'components/create/Contact';
-//import {Skills, Introduction, WorkHistory, Contact, Project} from 'components/create';
 import Project from 'components/create/Project';
-import { stringify } from 'querystring';
 import Review from 'components/create/Review';
+const PAGE_TITLES = [
+  'Personal Information',
+  'Work History',
+  'Skills',
+  'Projects',
+  'Contact Information',
+];
 const CreatePortfolioPage: NextPage = () => {
   const portfolioClient = new PortfolioApiClient();
   const router = useRouter();
@@ -29,7 +34,6 @@ const CreatePortfolioPage: NextPage = () => {
   if (isSubmitting) {
     return <CircularProgress />;
   }
-  //
   const onSubmit = async () => {
     setIsSubmitting(true);
     const portfolio = await portfolioClient.put({
@@ -43,18 +47,11 @@ const CreatePortfolioPage: NextPage = () => {
         projects,
         contact,
       },
-      //
     });
     router.push(`/portfolio/${portfolio?.id}`);
     console.log(portfolio);
   };
-  const pageTitles = [
-    'Personal Information',
-    'Work History',
-    'Skills',
-    'Projects',
-    'Contact Information',
-  ];
+
   const PageDisplay = () => {
     if (page === 0) {
       return <Introduction />;
@@ -81,7 +78,7 @@ const CreatePortfolioPage: NextPage = () => {
       );
     }
   };
-  console.log(title);
+
   return (
     <CreatePortfolioContext.Provider
       value={{
@@ -104,13 +101,13 @@ const CreatePortfolioPage: NextPage = () => {
       }}
     >
       <div>
-        <Typography variant="h3">{pageTitles[page]}</Typography>
+        <Typography variant="h3">{PAGE_TITLES[page]}</Typography>
       </div>
       <div>{PageDisplay()}</div>
       <Button
         variant="outlined"
         color="secondary"
-        disabled={page == 0}
+        disabled={page === 0}
         onClick={() => {
           setPage((currPage) => currPage - 1);
         }}
@@ -120,7 +117,7 @@ const CreatePortfolioPage: NextPage = () => {
       <Button
         variant="outlined"
         color="primary"
-        disabled={page == 5}
+        disabled={page === PAGE_TITLES.length}
         onClick={() => {
           setPage((currPage) => currPage + 1);
         }}

--- a/utils/clients/PortfolioDbClient.ts
+++ b/utils/clients/PortfolioDbClient.ts
@@ -120,7 +120,7 @@ function unmarshalPortfolio(
           label: link?.M?.label?.S || '',
           url: link?.M?.url?.S || '',
         })) as PortfolioDefinitions.ILink[],
-        email: portfolio?.content?.M?.contact?.M?.email || '',
+        email: portfolio?.content?.M?.contact?.M?.email?.S || '',
       } as PortfolioDefinitions.IContact,
     },
   };


### PR DESCRIPTION
## [STRUCTURE] Update create page
Authored by: @vuminhdiep  and @mohsley 

## What?
Added several new components to get user information for a portfolio. The layout will likely change after the branding update, the main focus was getting data, styling/layout will come next.

## Why?
Previously, the only interaction a user could have when creating a portfolio was to add a title. This update will expose every other datapoint of a portfolio as well as display entered information back to the user before creating.

## How?
A new folder labeled components was made with a sub create directory. This directory contains the several different components that we render to the use to get their information including:

_**Create.tsx:**_ The main component the renders the rest using next, previous, and submits all data to database with a submit button. We maintain state by warping all components with a defined context.

_**CreatePortfolioContext.tsx**_ Defines a global context for the create component and its children so we don't have to send data up and down daisy chained.

_**Introduction.tsx**_ Get personal information about the user.

_**WorkHistory.tsx**_ Get work history from the user.

_**Skills.tsx**_ Get tech and soft skills from the user.

_**Project.tsx**_ Get a list of projects from the user.

_**Contact.tsx:**_ Get contact information from user.

_**Review.tsx:**_ Display all user information in a barebones format so they can see what they worked on. (will be updated after View Page update to look nicer)

## Testing? 
We used the Review page to test as well as creating and viewing in the database.